### PR TITLE
fixes cases when json_encode(null) returns 'null' on Before and After

### DIFF
--- a/code/dataobjects/DataChangeRecord.php
+++ b/code/dataobjects/DataChangeRecord.php
@@ -171,13 +171,13 @@ class DataChangeRecord extends DataObject {
 			}
 		}
 
-		if($this->Before && is_array($before)) {
+		if($this->Before && $this->Before !== 'null' && is_array($before)) {
 			//merge the old array last to keep it's value as we want keep the earliest version of each field
 			$this->Before = json_encode(array_replace(json_decode($this->Before, true), $before));
 		} else {
 			$this->Before = json_encode($before);
 		}
-		if ($this->After && is_array($after)) {
+		if ($this->After && $this->After !== 'null' && is_array($after)) {
 			//merge the new array last to keep it's value as we want the newest version of each field
 			$this->After = json_encode(array_replace($after, json_decode($this->After, true)));
 		} else {


### PR DESCRIPTION
Discovered while attempting to import `ResourcePage`s in Rubik's project